### PR TITLE
removed invalid checks for getting an object's bucket/key

### DIFF
--- a/include/object.hpp
+++ b/include/object.hpp
@@ -80,12 +80,10 @@ object::object(object&& other)
 }
 
 const std::string& object::bucket() const {
-  check_valid();
   return bucket_;
 }
 
 const std::string& object::key() const {
-  check_valid();
   return key_;
 }
 

--- a/include/object.hpp
+++ b/include/object.hpp
@@ -14,8 +14,6 @@ class object {
   typedef pbc::RpbContent content;
   typedef google::protobuf::RepeatedPtrField<content> sibling_vector;
 
-  object() : valid_{false} {}
-
   inline object(std::string bucket, std::string key);
 
   inline object(object&& other);
@@ -44,6 +42,7 @@ class object {
   inline void resolve_with(content&& new_content);
 
   bool valid() const { return valid_; }
+  void valid(bool validity_) { valid_ = validity_; }
   bool exists() const { check_no_conflict(); return exists_; }
   bool in_conflict() const { check_valid(); return siblings_.size() > 1; }
 

--- a/test/object_test.cpp
+++ b/test/object_test.cpp
@@ -52,6 +52,7 @@ object make_object(std::string bucket, std::string key, std::string vclock,
 
 TEST(ObjectTest, ValidityConditions) {
   object o1{{}, {}};
+  EXPECT_TRUE(o1.valid());
   o1.valid(false);
   object o2 = o1;
   object o3{"b", "k"};
@@ -70,6 +71,7 @@ TEST(ObjectTest, ValidityConditions) {
   object p1{"b", "k"};
   object p2 = make_object("b", "k", "123", {});
   object p3 = p1;
+  EXPECT_TRUE(p3.valid());
   object p4{{}, {}};
   p4.valid(false);
   p4 = p2;


### PR DESCRIPTION
I removed checking if an object is invalid when getting its bucket or key. It makes error handling cleaner, e.g if you do a fetch that fails, the callback handler is still passed an object which with the bucket/key set + an error code. Alternatively, the user would need to pass the bucket & key manually to handlers in order to make sure the handler has this information even if the operation fails.
