### PR TITLE
More std::move

### DIFF
--- a/include/async_queue.hpp
+++ b/include/async_queue.hpp
@@ -76,7 +76,7 @@ void async_queue<Element>::async_pop(HandlerConvertible&& handler) {
     elements_.pop();
     lock.unlock();
     if (should_signal) elements_full_.notify_one();
-    handler(element);
+    handler(std::move(element));
   }
 }
 

--- a/include/client.hpp
+++ b/include/client.hpp
@@ -50,7 +50,7 @@ class client {
 
   ~client();
 
-  bool manages_io_service() const { return io_service_; }
+  bool manages_io_service() const { return static_cast<bool>(threads_); }
   inline boost::asio::io_service& io_service() const;
 
   void run_managed();
@@ -235,7 +235,6 @@ void client::fetch_wrapper(Handler& handler, std::string& bucket,
 template <class Handler>
 void client::store_wrapper(Handler& handler, std::error_code error,
                            const std::string& serialized) {
-
   pbc::RpbPutResp response;
   parse(pbc::PUT_RESP, serialized, response, error);
   handler(error);

--- a/src/length_framed_connection.cpp
+++ b/src/length_framed_connection.cpp
@@ -9,7 +9,6 @@
 
 #include "byte_order.hpp"
 #include "check.hpp"
-#include "debug_log.hpp"
 #include "endpoint_vector.hpp"
 
 namespace riak {
@@ -131,7 +130,7 @@ void length_framed_connection::report(std::errc ec) {
                                     std::move(payload_buffer_));
   accepts_requests_.store(true);
   timer_.cancel();
-  strand_.get_io_service().post(postable_handler);
+  strand_.get_io_service().post(std::move(postable_handler));
 }
 
 inline void length_framed_connection::report(boost::system::error_code ec) {


### PR DESCRIPTION
Moves were missing in async_queue for popped elements and in length_framed_connection for posting handlers.

Together with Boost 1.55 this completely removes all handler copies.
